### PR TITLE
Installed 'car' script via 'pip install c64os-util' doesn't run due to missing scripts directory. Also walk() path issue.

### DIFF
--- a/c64os_util/car/record/header.py
+++ b/c64os_util/car/record/header.py
@@ -15,7 +15,7 @@ class ArchiveRecordHeader:
     properties to access the underlying fields.
     """
 
-    MAX_NAME_SIZE = 15
+    MAX_NAME_SIZE = 16
 
     def __init__(
         self,
@@ -85,7 +85,6 @@ class ArchiveRecordHeader:
         name_bytes = self.name.encode(LC_CODEC)
         name_bytes = name_bytes.ljust(ArchiveRecordHeader.MAX_NAME_SIZE, b"\xA0")
         buffer.write(name_bytes)
-        buffer.write(b"\0")  # ???
         self.compression_type.serialize(buffer)
 
     @staticmethod
@@ -101,7 +100,6 @@ class ArchiveRecordHeader:
         size = int.from_bytes(buffer.read(3), "little")
         name_bytes = buffer.read(ArchiveRecordHeader.MAX_NAME_SIZE)
         name = name_bytes.rstrip(b"\xA0").decode(LC_CODEC)
-        buffer.read(1)  # ???
         compression_type = CarCompressionType.deserialize(buffer)
         return ArchiveRecordHeader(
             name=name,

--- a/c64os_util/car/record/record.py
+++ b/c64os_util/car/record/record.py
@@ -454,7 +454,7 @@ class ArchiveDirectory(ArchiveRecord, list):
         path.append(self.name)
         yield path, self
         for record in self.directories():
-            yield from record._walk(path)  # pylint: disable=W0212
+            yield from record._walk(path.copy())  # pylint: disable=W0212
 
     def serialize(self, buffer: typing.BinaryIO):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 include = [
     "LICENSE",
 ]
-packages = [{include = "c64os_util"}]
+packages = [{include = "c64os_util"}, {include = "scripts"}]
 
 [tool.poetry.dependencies]
 python = ">=3.10,<4.0"


### PR DESCRIPTION
I'm not sure if this is the correct fix for the scripts directory but it makes the 'car' created from pip install run.  Otherwise it tries to import scripts.car and nothing from scripts is installed.

Second in ArchiveDirectory._walk() the function is called recursively with the same 'path' list which gets all directories encountered appended.  Passing path.copy() means we start with just the current path and above each time we descend/recurse.
